### PR TITLE
fix: Create shasum file to be compatible with VMware

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,17 +15,21 @@ image: deps
 
 vmdk: image
 	@echo "Convert to VMware disk image"
-	@qemu-img convert image/packer-base-ubuntu-cloud-amd64 -O vmdk -o adapter_type=lsilogic,subformat=streamOptimized,compat6 image/onms-hzn-0.vmdk
+	@qemu-img convert image/packer-base-ubuntu-cloud-amd64 -O vmdk -o adapter_type=lsilogic,subformat=streamOptimized,compat6 image/onms-hzn-1.vmdk
 
-manifest: vmdk
-	@echo "Create VMware file and manifest"
+checksum: vmdk
+	@echo "Create VMware file and checksum"
 	@cp template.ovf image/onms-hzn.ovf
-	@cd image && sha256sum --tag onms-hzn.ovf onms-hzn-0.vmdk > onms-hzn.mf
+	@cd image && sha256sum --tag onms-hzn.ovf onms-hzn-1.vmdk > sha256.sum && \
+
+manifest: checksum
+	@echo "Create VMware compatible manifest with custom checksum file"
+	@cd image && sed 's/SHA256 (/SHA256(/' sha256.sum | sed 's/) =/)=/' > onms-hzn.mf
 
 ova: manifest
 	@echo "Create OVA file"
 	@cd image && \
-	tar -cvf onms-hzn-vm.ova onms-hzn.ovf onms-hzn.mf onms-hzn-0.vmdk && \
+	tar -cvf onms-hzn-vm.ova onms-hzn.ovf onms-hzn.mf onms-hzn-1.vmdk && \
 	sha256sum --tag -b onms-hzn-vm.ova > onms-hzn-vm.shasum
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,9 @@ ova: manifest
 	@cd image && \
 	tar -cvf onms-hzn-vm.ova onms-hzn.ovf onms-hzn.mf onms-hzn-1.vmdk && \
 	sha256sum --tag -b onms-hzn-vm.ova > onms-hzn-vm.shasum
+	@echo "Cleanup QEMU image and VMDK file"
+	@rm image/packer-base-ubuntu-cloud-amd64
+	@rm image/onms-hzn-1.vmdk
 
 clean:
 	@echo "Delete image build artifacts"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: deps image vmdk ova clean
+.PHONY: deps image vmdk checksum manifest ova clean
 
 .DEFAULT_GOAL := ova
 
@@ -20,7 +20,7 @@ vmdk: image
 checksum: vmdk
 	@echo "Create VMware file and checksum"
 	@cp template.ovf image/onms-hzn.ovf
-	@cd image && sha256sum --tag onms-hzn.ovf onms-hzn-1.vmdk > sha256.sum && \
+	@cd image && sha256sum --tag onms-hzn.ovf onms-hzn-1.vmdk > sha256.sum
 
 manifest: checksum
 	@echo "Create VMware compatible manifest with custom checksum file"

--- a/build.pkr.hcl
+++ b/build.pkr.hcl
@@ -11,7 +11,7 @@ build {
   source "source.qemu.base-ubuntu-cloud-amd64" {
     name                    = "onms-hzn"
     iso_url                 = local.iso_url_ubuntu_cloud_2204
-    iso_checksum            = local.iso_checksum_url_ubuntu_cloud_2204
+    iso_checksum            = "file:${local.iso_checksum_url_ubuntu_cloud_2204}"
     output_directory        = "image"
     accelerator             = "none"
     http_directory          = local.http_directory

--- a/source.qemu.pkr.hcl
+++ b/source.qemu.pkr.hcl
@@ -5,7 +5,7 @@ source "qemu" "base-ubuntu-cloud-amd64" {
   boot_wait        = "5s"
   disk_compression = true
   disk_image       = true
-  disk_size        = "30G"
+  disk_size        = "100G"
   disk_interface   = "virtio-scsi"
   format           = "qcow2"
   qemuargs         = [["-smbios", "type=1,serial=ds=nocloud-net;s=http://{{ .HTTPIP }}:{{ .HTTPPort }}/"]]

--- a/source.qemu.pkr.hcl
+++ b/source.qemu.pkr.hcl
@@ -8,7 +8,6 @@ source "qemu" "base-ubuntu-cloud-amd64" {
   disk_size        = "30G"
   disk_interface   = "virtio-scsi"
   format           = "qcow2"
-  #qemuargs         = [["-cdrom", "init.iso"]]
   qemuargs         = [["-smbios", "type=1,serial=ds=nocloud-net;s=http://{{ .HTTPIP }}:{{ .HTTPPort }}/"]]
   shutdown_command = "echo 'ubuntu' | sudo -S shutdown -P now"
   ssh_username     = "ubuntu"

--- a/template.ovf
+++ b/template.ovf
@@ -1,21 +1,21 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Envelope xmlns="http://schemas.dmtf.org/ovf/envelope/1" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData">
   <References>
-    <File ovf:href="onms-hzn-0.vmdk" ovf:id="file1" ovf:size="3343607808"/>
+    <File ovf:id="file1" ovf:href="onms-hzn-1.vmdk"/>
   </References>
   <DiskSection>
     <Info>List of the virtual disks</Info>
-        <Disk ovf:capacity="30" ovf:capacityAllocationUnits="byte * 2^30" ovf:diskId="vmdisk1" ovf:fileRef="file1" ovf:format="http://www.vmware.com/interfaces/specifications/vmdk.html#streamOptimized"/>
+    <Disk ovf:capacityAllocationUnits="byte" ovf:format="http://www.vmware.com/interfaces/specifications/vmdk.html#streamOptimized" ovf:diskId="vmdisk1" ovf:capacity="107374182400" ovf:fileRef="file1"/>
   </DiskSection>
   <NetworkSection>
     <Info>List of logical networks used in the package</Info>
     <Network ovf:name="Network 1">
-      <Description>The &quot;Network 1&quot; network</Description>
+      <Description>The Network 1 network</Description>
     </Network>
   </NetworkSection>
-  <VirtualSystem ovf:id="onms-hzn-vm">
-    <Info>A virtual machine</Info>
-    <Name>onms-hzn-vm</Name>
+  <VirtualSystem ovf:id="opennms-horizon-vm">
+    <Info>A Virtual system</Info>
+    <Name>opennms-horizon-vm</Name>
     <OperatingSystemSection ovf:id="94" vmw:osType="ubuntu64Guest">
       <Info>The operating system installed</Info>
       <Description>Ubuntu Linux (64-bit)</Description>
@@ -25,50 +25,56 @@
       <System>
         <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
         <vssd:InstanceID>0</vssd:InstanceID>
-        <vssd:VirtualSystemIdentifier>onms-hzn-vm</vssd:VirtualSystemIdentifier>
         <vssd:VirtualSystemType>vmx-13</vssd:VirtualSystemType>
       </System>
       <Item>
-        <rasd:Caption>4 virtual CPU</rasd:Caption>
-        <rasd:Description>Number of virtual CPUs</rasd:Description>
-        <rasd:ElementName>4 virtual CPU</rasd:ElementName>
+        <rasd:AllocationUnits>hertz * 10^6</rasd:AllocationUnits>
+        <rasd:Description>Number of Virtual CPUs</rasd:Description>
+        <rasd:ElementName>4 virtual CPU(s)</rasd:ElementName>
         <rasd:InstanceID>1</rasd:InstanceID>
         <rasd:ResourceType>3</rasd:ResourceType>
         <rasd:VirtualQuantity>4</rasd:VirtualQuantity>
+        <vmw:CoresPerSocket ovf:required="false">1</vmw:CoresPerSocket>
       </Item>
       <Item>
         <rasd:AllocationUnits>byte * 2^20</rasd:AllocationUnits>
         <rasd:Description>Memory Size</rasd:Description>
-        <rasd:ElementName>8192MB of memory</rasd:ElementName>
+        <rasd:ElementName>16384MB of memory</rasd:ElementName>
         <rasd:InstanceID>2</rasd:InstanceID>
         <rasd:ResourceType>4</rasd:ResourceType>
-        <rasd:VirtualQuantity>8192</rasd:VirtualQuantity>
+        <rasd:VirtualQuantity>16384</rasd:VirtualQuantity>
+      </Item>
+      <Item>
+        <rasd:Address>0</rasd:Address>
+        <rasd:Description>SCSI Controller</rasd:Description>
+        <rasd:ElementName>SCSI Controller 1</rasd:ElementName>
+        <rasd:InstanceID>3</rasd:InstanceID>
+        <rasd:ResourceSubType>lsilogicsas</rasd:ResourceSubType>
+        <rasd:ResourceType>6</rasd:ResourceType>
       </Item>
       <Item>
         <rasd:Address>0</rasd:Address>
         <rasd:Description>SATA Controller</rasd:Description>
         <rasd:ElementName>SATA Controller 1</rasd:ElementName>
-        <rasd:InstanceID>3</rasd:InstanceID>
+        <rasd:InstanceID>4</rasd:InstanceID>
         <rasd:ResourceSubType>vmware.sata.ahci</rasd:ResourceSubType>
         <rasd:ResourceType>20</rasd:ResourceType>
-        <vmw:Config ovf:required="false" vmw:key="slotInfo.pciSlotNumber" vmw:value="34"/>
       </Item>
       <Item>
         <rasd:AddressOnParent>0</rasd:AddressOnParent>
-        <rasd:Caption>disk1</rasd:Caption>
-        <rasd:Description>Disk Image</rasd:Description>
-        <rasd:ElementName>disk1</rasd:ElementName>
-        <rasd:HostResource>/disk/vmdisk1</rasd:HostResource>
-        <rasd:InstanceID>4</rasd:InstanceID>
+        <rasd:ElementName>Hard Disk 1</rasd:ElementName>
+        <rasd:HostResource>ovf:/disk/vmdisk1</rasd:HostResource>
+        <rasd:InstanceID>5</rasd:InstanceID>
         <rasd:Parent>3</rasd:Parent>
         <rasd:ResourceType>17</rasd:ResourceType>
       </Item>
       <Item>
+        <rasd:AddressOnParent>0</rasd:AddressOnParent>
         <rasd:AutomaticAllocation>true</rasd:AutomaticAllocation>
         <rasd:Connection>Network 1</rasd:Connection>
-        <rasd:ElementName xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData">Ethernet adapter on &quot;Network 1&quot;</rasd:ElementName>
-        <rasd:InstanceID xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData">5</rasd:InstanceID>
-        <rasd:ResourceSubType>vmxnet3</rasd:ResourceSubType>
+        <rasd:ElementName>Network adapter 1</rasd:ElementName>
+        <rasd:InstanceID>7</rasd:InstanceID>
+        <rasd:ResourceSubType>VmxNet3</rasd:ResourceSubType>
         <rasd:ResourceType>10</rasd:ResourceType>
       </Item>
     </VirtualHardwareSection>

--- a/template.ovf
+++ b/template.ovf
@@ -1,11 +1,11 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<Envelope ovf:version="1.0" xml:lang="en-US" xmlns="http://schemas.dmtf.org/ovf/envelope/1" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData">
+<?xml version='1.0' encoding='UTF-8'?>
+<Envelope xmlns="http://schemas.dmtf.org/ovf/envelope/1" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData">
   <References>
-    <File ovf:href="onms-hzn-0.vmdk" ovf:id="file1" ovf:size="3343607808"/>
+    <File ovf:id="file1" ovf:href="onms-hzn-1.vmdk"/>
   </References>
   <DiskSection>
-    <Info>List of the virtual disks used in the package</Info>
-    <Disk ovf:capacity="30" ovf:capacityAllocationUnits="byte * 2^30" ovf:diskId="vmdisk1" ovf:fileRef="file1" ovf:format="http://www.vmware.com/interfaces/specifications/vmdk.html#streamOptimized"/>
+    <Info>List of the virtual disks</Info>
+    <Disk ovf:capacityAllocationUnits="byte" ovf:format="http://www.vmware.com/interfaces/specifications/vmdk.html#streamOptimized" ovf:diskId="vmdisk1" ovf:capacity="3343607808" ovf:fileRef="file1"/>
   </DiskSection>
   <NetworkSection>
     <Info>List of logical networks used in the package</Info>
@@ -15,12 +15,13 @@
   </NetworkSection>
   <VirtualSystem ovf:id="onms-hzn-vm">
     <Info>A virtual machine</Info>
-    <OperatingSystemSection ovf:id="94">
-      <Info>The kind of installed guest operating system</Info>
-      <Description>Ubuntu_64</Description>
+    <Name>onms-hzn-vm</Name>
+    <OperatingSystemSection ovf:id="94" vmw:osType="ubuntu64Guest">
+      <Info>The operating system installed</Info>
+      <Description>Ubuntu Linux (64-bit)</Description>
     </OperatingSystemSection>
     <VirtualHardwareSection>
-      <Info>Virtual hardware requirements for a virtual machine</Info>
+      <Info>Virtual hardware requirements</Info>
       <System>
         <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
         <vssd:InstanceID>0</vssd:InstanceID>
@@ -36,10 +37,9 @@
         <rasd:VirtualQuantity>4</rasd:VirtualQuantity>
       </Item>
       <Item>
-        <rasd:AllocationUnits>MegaBytes</rasd:AllocationUnits>
-        <rasd:Caption>8192 MB of memory</rasd:Caption>
+        <rasd:AllocationUnits>byte * 2^20</rasd:AllocationUnits>
         <rasd:Description>Memory Size</rasd:Description>
-        <rasd:ElementName>8192 MB of memory</rasd:ElementName>
+        <rasd:ElementName>8192MB of memory</rasd:ElementName>
         <rasd:InstanceID>2</rasd:InstanceID>
         <rasd:ResourceType>4</rasd:ResourceType>
         <rasd:VirtualQuantity>8192</rasd:VirtualQuantity>

--- a/template.ovf
+++ b/template.ovf
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <Envelope xmlns="http://schemas.dmtf.org/ovf/envelope/1" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData">
   <References>
-    <File ovf:id="file1" ovf:href="onms-hzn-1.vmdk"/>
+    <File ovf:href="onms-hzn-0.vmdk" ovf:id="file1" ovf:size="3343607808"/>
   </References>
   <DiskSection>
     <Info>List of the virtual disks</Info>
-    <Disk ovf:capacityAllocationUnits="byte" ovf:format="http://www.vmware.com/interfaces/specifications/vmdk.html#streamOptimized" ovf:diskId="vmdisk1" ovf:capacity="3343607808" ovf:fileRef="file1"/>
+        <Disk ovf:capacity="30" ovf:capacityAllocationUnits="byte * 2^30" ovf:diskId="vmdisk1" ovf:fileRef="file1" ovf:format="http://www.vmware.com/interfaces/specifications/vmdk.html#streamOptimized"/>
   </DiskSection>
   <NetworkSection>
     <Info>List of logical networks used in the package</Info>

--- a/variables.22.04.pkr.hcl
+++ b/variables.22.04.pkr.hcl
@@ -1,5 +1,5 @@
 locals {
   iso_url_ubuntu_cloud_2204           = "https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img"
-  iso_checksum_url_ubuntu_cloud_2204  = "sha256:0ebb968aabb05ca50794dcf48f695aa7be3381ae00bcac9b8571f3ef369967a9"
+  iso_checksum_url_ubuntu_cloud_2204  = "sha256:2081b51ccb47acb54012db3a55fe22d3add2507311f6a4b16c41fc45f03d4d33"
   http_directory                      = "./seed"
 }

--- a/variables.22.04.pkr.hcl
+++ b/variables.22.04.pkr.hcl
@@ -1,5 +1,5 @@
 locals {
   iso_url_ubuntu_cloud_2204           = "https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img"
-  iso_checksum_url_ubuntu_cloud_2204  = "sha256:2081b51ccb47acb54012db3a55fe22d3add2507311f6a4b16c41fc45f03d4d33"
+  iso_checksum_url_ubuntu_cloud_2204  = "https://cloud-images.ubuntu.com/jammy/current/SHA256SUMS"
   http_directory                      = "./seed"
 }


### PR DESCRIPTION
The VMware checksum in the manifest needs to be in the exact format including just one whitespace between `= <checksum>`
```
SHA256(<filename>)= <checksum>
```

Resolve: #3 
Resolve: #5 